### PR TITLE
feat: upgrade plugin to support OpenSearch 3.1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [17,21]
+        java: [21]
     name: Build and Test Plugin Template
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: '17'
+          java-version: '21'
 
       # Build the project
       - name: Build project

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ NOTE: OpenSearch plugins much match _exactly_ in major.minor.path version to the
 
 | OpenSearch |      Plugin |  Release date |
 |-----------:|------------:|--------------:|
+|     3.1.0  |    3.1.0.0  |    2025-07-08 |
 |     2.19.2 |    2.19.2.0 |    2025-06-04 |
 |     2.19.0 |    2.19.0.0 |    2025-11-14 |
 |     2.18.0 |    2.18.0.0 |    2025-01-02 |

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
                 "prometheus": "0.16.0"
         ]
 
-        bwcPluginDownloadLink = 'https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v' +
+        bwcPluginDownloadLink = 'https://github.com/sapcc/prometheus-exporter-plugin-for-opensearch/releases/download/v' +
                 project.BWCversion + '/prometheus-exporter-' + project.BWCPluginVersion + '.zip'
         baseName = "bwcCluster"
         bwcFilePath = "src/test/resources/org/opensearch/prometheus-exporter/bwc/"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 #group = org.opensearch.plugin.prometheus
 
 # An actual version of plugin
-version = 2.19.2.0
+version = 3.1.0.0
 
 # Leave this property empty, it is assigned during the gradle build execution (yes, it is a hack! see issue #324)
 opensearch_version =
 
 # A version of OpenSearch cluster to run BWC tests against
-BWCversion = 2.19.1
+BWCversion = 3.1.0
 
 # A version of plugin to deploy to BWC clusters
-BWCPluginVersion = 2.19.1.0
+BWCPluginVersion = 3.1.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,10 @@ version = 3.1.0.0
 opensearch_version =
 
 # A version of OpenSearch cluster to run BWC tests against
-BWCversion = 3.1.0
+BWCversion = 2.19.2
 
 # A version of plugin to deploy to BWC clusters
-BWCPluginVersion = 3.1.0.0
+BWCPluginVersion = 2.19.2.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
@@ -41,6 +41,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
+import org.opensearch.client.node.NodeClient;
 
 /**
  * Transport action class for Prometheus Exporter plugin.
@@ -55,19 +56,22 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
     private final ClusterSettings clusterSettings;
     private final PrometheusSettings prometheusSettings;
     private final Logger logger = LogManager.getLogger(getClass());
+    private final NodeClient client;
 
     /**
      * A constructor.
      * @param settings Settings
+     * @param client Node client
      * @param transportService Transport service
      * @param actionFilters Action filters
      * @param clusterSettings Cluster settings
      */
     @Inject
-    public TransportNodePrometheusMetricsAction(Settings settings, TransportService transportService,
+    public TransportNodePrometheusMetricsAction(Settings settings, NodeClient client, TransportService transportService,
                                                 ActionFilters actionFilters, ClusterSettings clusterSettings) {
         super(NodePrometheusMetricsAction.NAME, transportService, actionFilters,
                 NodePrometheusMetricsRequest::new);
+        this.client = client;
         this.settings = settings;
         this.clusterSettings = clusterSettings;
         this.prometheusSettings = new PrometheusSettings(settings, clusterSettings);

--- a/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
@@ -51,7 +51,6 @@ import org.opensearch.transport.TransportService;
  */
 public class TransportNodePrometheusMetricsAction extends HandledTransportAction<NodePrometheusMetricsRequest,
         NodePrometheusMetricsResponse> {
-    private final org.opensearch.client.internal.Client client;
     private final Settings settings;
     private final ClusterSettings clusterSettings;
     private final PrometheusSettings prometheusSettings;
@@ -60,18 +59,15 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
     /**
      * A constructor.
      * @param settings Settings
-     * @param client Cluster client
      * @param transportService Transport service
      * @param actionFilters Action filters
      * @param clusterSettings Cluster settings
      */
     @Inject
-    public TransportNodePrometheusMetricsAction(Settings settings, org.opensearch.client.internal.Client client,
-                                                TransportService transportService, ActionFilters actionFilters,
-                                                ClusterSettings clusterSettings) {
+    public TransportNodePrometheusMetricsAction(Settings settings, TransportService transportService,
+                                                ActionFilters actionFilters, ClusterSettings clusterSettings) {
         super(NodePrometheusMetricsAction.NAME, transportService, actionFilters,
                 NodePrometheusMetricsRequest::new);
-        this.client = client;
         this.settings = settings;
         this.clusterSettings = clusterSettings;
         this.prometheusSettings = new PrometheusSettings(settings, clusterSettings);

--- a/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
@@ -34,8 +34,6 @@ import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
-import org.opensearch.client.Client;
-import org.opensearch.client.Requests;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.ClusterSettings;
@@ -53,7 +51,7 @@ import org.opensearch.transport.TransportService;
  */
 public class TransportNodePrometheusMetricsAction extends HandledTransportAction<NodePrometheusMetricsRequest,
         NodePrometheusMetricsResponse> {
-    private final Client client;
+    private final org.opensearch.client.internal.Client client;
     private final Settings settings;
     private final ClusterSettings clusterSettings;
     private final PrometheusSettings prometheusSettings;
@@ -68,7 +66,7 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
      * @param clusterSettings Cluster settings
      */
     @Inject
-    public TransportNodePrometheusMetricsAction(Settings settings, Client client,
+    public TransportNodePrometheusMetricsAction(Settings settings, org.opensearch.client.internal.Client client,
                                                 TransportService transportService, ActionFilters actionFilters,
                                                 ClusterSettings clusterSettings) {
         super(NodePrometheusMetricsAction.NAME, transportService, actionFilters,
@@ -119,17 +117,12 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
         private AsyncAction(ActionListener<NodePrometheusMetricsResponse> listener) {
             this.listener = listener;
 
-            // Note: when using ClusterHealthRequest in Java, it pulls data at the shards level, according to ES source
-            // code comment this is "so it is backward compatible with the transport client behaviour".
-            // hence we are explicit about ClusterHealthRequest level and do not rely on defaults.
-            // https://www.elastic.co/guide/en/elasticsearch/reference/6.4/cluster-health.html#request-params
-            this.healthRequest = Requests.clusterHealthRequest().local(true);
+            this.healthRequest = new ClusterHealthRequest().local(true);
             this.healthRequest.level(ClusterHealthRequest.Level.SHARDS);
 
-            // We want to get only the most minimal static info from local node (cluster name, node name and nodeID).
-            this.localNodesInfoRequest = Requests.nodesInfoRequest("_local").clear();
+            this.localNodesInfoRequest = new NodesInfoRequest("_local").clear();
 
-            this.nodesStatsRequest = Requests.nodesStatsRequest(prometheusNodesFilter).clear().all();
+            this.nodesStatsRequest = new NodesStatsRequest(prometheusNodesFilter).clear().all();
 
             // Indices stats request is not "node-specific", it does not support any "_local" notion
             // it is broad-casted to all cluster nodes.
@@ -144,8 +137,7 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
 
             // Cluster settings are get via ClusterStateRequest (see elasticsearch RestClusterGetSettingsAction for details)
             // We prefer to send it to master node (hence local=false; it should be set by default but we want to be sure).
-            this.clusterStateRequest = isPrometheusClusterSettings ? Requests.clusterStateRequest()
-                    .clear().metadata(true).local(false) : null;
+            this.clusterStateRequest = isPrometheusClusterSettings ? new ClusterStateRequest().clear().metadata(true).local(false) : null;
         }
 
         private void gatherRequests() {

--- a/src/main/java/org/opensearch/rest/prometheus/RestPrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/rest/prometheus/RestPrometheusMetricsAction.java
@@ -34,6 +34,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.*;
 import org.opensearch.rest.action.RestResponseListener;
+import org.opensearch.client.node.NodeClient;
 
 import java.util.List;
 import java.util.Locale;
@@ -90,10 +91,8 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
         return "prometheus_metrics_action";
     }
 
-     // This method does not throw any IOException because there are no request parameters to be parsed
-     // and processed. This may change in the future.
     @Override
-    protected RestChannelConsumer prepareRequest(RestRequest request) {
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         if (logger.isTraceEnabled()) {
             String remoteAddress = NetworkAddress.format(request.getHttpChannel().getRemoteAddress());
             logger.trace(String.format(Locale.ENGLISH, "Received request for Prometheus metrics from %s",
@@ -101,6 +100,41 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
         }
 
         NodePrometheusMetricsRequest metricsRequest = new NodePrometheusMetricsRequest();
-        return channel -> channel.dispatchRequest(metricsRequest);
+
+        return channel -> client.execute(INSTANCE, metricsRequest,
+                new RestResponseListener<NodePrometheusMetricsResponse>(channel) {
+
+                    @Override
+                    public RestResponse buildResponse(NodePrometheusMetricsResponse response) throws Exception {
+
+                        String clusterName = response.getLocalNodesInfoResponse().getClusterName().value();
+                        assert response.getLocalNodesInfoResponse().getNodes().size() == 1;
+                        String nodeName = response.getLocalNodesInfoResponse().getNodes().get(0).getNode().getName();
+                        String nodeId = response.getLocalNodesInfoResponse().getNodes().get(0).getNode().getId();
+
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Preparing metrics output on node: [{}], [{}]", nodeName, nodeId);
+                        }
+                        PrometheusMetricsCollector collector;
+                        String textContent;
+                        try {
+                            PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(clusterName, metricPrefix);
+                            collector = new PrometheusMetricsCollector(
+                                    catalog,
+                                    prometheusSettings.getPrometheusIndices(),
+                                    prometheusSettings.getPrometheusClusterSettings()
+                            );
+                            collector.registerMetrics();
+                            collector.updateMetrics(
+                                    nodeName, nodeId, response.getClusterHealth(), response.getNodeStats(),
+                                    response.getIndicesStats(), response.getClusterStatsData());
+                            textContent = collector.getTextContent();
+                        } catch (Exception ex) {
+                            logger.debug("Prometheus metric catalog processing failed", ex);
+                            throw ex;
+                        }
+                        return new BytesRestResponse(RestStatus.OK, textContent);
+                    }
+                });
     }
 }

--- a/src/main/java/org/opensearch/rest/prometheus/RestPrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/rest/prometheus/RestPrometheusMetricsAction.java
@@ -27,7 +27,6 @@ import org.compuscene.metrics.prometheus.PrometheusMetricsCollector;
 import org.compuscene.metrics.prometheus.PrometheusSettings;
 import org.opensearch.action.NodePrometheusMetricsRequest;
 import org.opensearch.action.NodePrometheusMetricsResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -94,7 +93,7 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
      // This method does not throw any IOException because there are no request parameters to be parsed
      // and processed. This may change in the future.
     @Override
-    protected RestChannelConsumer prepareRequest(RestRequest request, Client client) {
+    protected RestChannelConsumer prepareRequest(RestRequest request) {
         if (logger.isTraceEnabled()) {
             String remoteAddress = NetworkAddress.format(request.getHttpChannel().getRemoteAddress());
             logger.trace(String.format(Locale.ENGLISH, "Received request for Prometheus metrics from %s",
@@ -102,53 +101,6 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
         }
 
         NodePrometheusMetricsRequest metricsRequest = new NodePrometheusMetricsRequest();
-
-        return channel -> client.execute(INSTANCE, metricsRequest,
-                new RestResponseListener<NodePrometheusMetricsResponse>(channel) {
-
-                    @Override
-                    public RestResponse buildResponse(NodePrometheusMetricsResponse response) throws Exception {
-
-                        String clusterName = response.getLocalNodesInfoResponse().getClusterName().value();
-                        assert response.getLocalNodesInfoResponse().getNodes().size() == 1;
-                        String nodeName = response.getLocalNodesInfoResponse().getNodes().get(0).getNode().getName();
-                        String nodeId = response.getLocalNodesInfoResponse().getNodes().get(0).getNode().getId();
-
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Preparing metrics output on node: [{}], [{}]", nodeName, nodeId);
-                        }
-                        PrometheusMetricsCollector collector;
-                        String textContent;
-                        try {
-//                            PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(clusterName, nodeName, nodeId, metricPrefix);
-                            PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(clusterName, metricPrefix);
-                            collector = new PrometheusMetricsCollector(
-                                    catalog,
-                                    prometheusSettings.getPrometheusIndices(),
-                                    prometheusSettings.getPrometheusClusterSettings()
-                            );
-                            collector.registerMetrics();
-                            collector.updateMetrics(
-                                    nodeName, nodeId, response.getClusterHealth(), response.getNodeStats(),
-                                    response.getIndicesStats(), response.getClusterStatsData());
-                            textContent = collector.getTextContent();
-                        } catch (Exception ex) {
-                            // We use try-catch block to catch exception from Prometheus catalog and collector processing
-                            // and dump it into the log, otherwise client needs to know how to configure logging to output
-                            // exceptions that are thrown from
-                            // "RestResponseListener.buildResponse(Response response) throws Exception".
-                            // This is useful when metric_prefix value is not valid or when metric collector fails
-                            // generating text content. We may be able to get rid of this try-catch pattern
-                            // once we implement robust verification of custom metric prefix.
-                            // See https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/issues/11
-                            logger.debug("Prometheus metric catalog processing failed", ex);
-                            throw ex;
-                        }
-                        // Prometheus' metrics are exposed similarly the Pushgateway example except no real gateway
-                        // is used and the metrics are exposed directly via OpenSearch HTTP API instead.
-                        // See https://github.com/prometheus/client_java#exporting-to-a-pushgateway
-                        return new BytesRestResponse(RestStatus.OK, textContent);
-                    }
-                });
+        return channel -> channel.dispatchRequest(metricsRequest);
     }
 }

--- a/src/main/java/org/opensearch/rest/prometheus/RestPrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/rest/prometheus/RestPrometheusMetricsAction.java
@@ -27,7 +27,7 @@ import org.compuscene.metrics.prometheus.PrometheusMetricsCollector;
 import org.compuscene.metrics.prometheus.PrometheusSettings;
 import org.opensearch.action.NodePrometheusMetricsRequest;
 import org.opensearch.action.NodePrometheusMetricsResponse;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.client.Client;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -94,7 +94,7 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
      // This method does not throw any IOException because there are no request parameters to be parsed
      // and processed. This may change in the future.
     @Override
-    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+    protected RestChannelConsumer prepareRequest(RestRequest request, Client client) {
         if (logger.isTraceEnabled()) {
             String remoteAddress = NetworkAddress.format(request.getHttpChannel().getRemoteAddress());
             logger.trace(String.format(Locale.ENGLISH, "Received request for Prometheus metrics from %s",

--- a/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
@@ -34,8 +34,8 @@ import java.util.stream.Collectors;
  */
 public class PluginBackwardsCompatibilityIT extends OpenSearchRestTestCase {
 
-    public static final Version BWCVersion = Version.V_2_19_1;
-    public static final Version NewVersion = Version.V_2_19_2;
+    public static final Version BWCVersion = Version.V_2_19_2;
+    public static final Version NewVersion = Version.V_3_1_0;
 
     private static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"));
     private static final String CLUSTER_NAME = System.getProperty("tests.clustername");


### PR DESCRIPTION
### Summary

This PR upgrades the Prometheus Exporter Plugin for OpenSearch to support OpenSearch 3.1.0.

### Changes

- Bump plugin version to `3.1.0.0` in `gradle.properties`
- Update BWC (backwards compatibility) test versions:
  - `BWCVersion` set to `2.19.2`
  - `NewVersion` set to `3.1.0`
- Update compatibility matrix in `README.md` to include OpenSearch 3.1.0 and plugin 3.1.0.0 with the release date `2025-07-08`

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
